### PR TITLE
turbolinks off pour refresh show

### DIFF
--- a/app/javascript/controllers/sketch_controller.js
+++ b/app/javascript/controllers/sketch_controller.js
@@ -97,7 +97,7 @@ export default class extends Controller {
       this.likeFormTarget.classList.add("active");
       this.snapshotTarget.classList.add("show");
       this.snapImgTarget.src = data.image_url;
-      this._saveCanvasImageUrl();
+      this._saveCanvasImageUrl()
       this.screenshot = true;
       setTimeout(() => {
         this.screenshot = false;

--- a/app/views/songs/_autocomplete.html.erb
+++ b/app/views/songs/_autocomplete.html.erb
@@ -1,5 +1,5 @@
 <% search_results.each_with_index do |result, i| %>
-  <%= link_to song_path(result) do %>
+  <%= link_to "song?id=#{result.id}", data: { turbolinks: false } do %>
     <li class="list-group-item" role="option" data-autocomplete-value="<%= result.id %>">
       <strong><%= result.artist%></strong> - <%= result.name %> - <%= result.album %>
     </li>


### PR DESCRIPTION
turbolinks désactivé pour rafraichir convenablement la show et load le canvas ! ok pour push heroku